### PR TITLE
mako_requirements

### DIFF
--- a/0.no_security/demo.py
+++ b/0.no_security/demo.py
@@ -274,6 +274,8 @@ def main(global_settings, **settings):
     config.add_route('page', '/page/{title}')
     config.add_route('edit_page', '/page/{title}/edit')
 
+
+    config.include('pyramid_mako')
     config.scan(__name__)
     return config.make_wsgi_app()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+Chameleon==2.16
+Mako==1.0.0
+MarkupSafe==0.23
+PasteDeploy==1.5.2
+WebOb==1.4
+pyramid==1.5.1
+pyramid-chameleon==0.1
+pyramid-mako==1.0.2
+repoze.lru==0.6
+translationstring==1.1
+venusian==1.0a8
+wsgiref==0.1.2
+zope.deprecation==4.1.1
+zope.interface==4.1.1


### PR DESCRIPTION
I couldn't run the demo app without installing some extra requirements and adding some configuration.

This pull includes the following changes:
- add a `requirements.txt` to top-level working directory to declare dependencies
- include `python_mako` package into "Demo 0" app.

To run the "Demo 0" project I have to do the following (assuming `virtualenv` is installed):

``` bash
$ mkvritualenv --no-site-packages pyramid_auth_demo
$ pip install -r requirements.txt
$ cd demo0
$ python demo.py
```

Once the correct pip packages are installed and the configuration line is added, the app works fine!  I go to [http://localhost:5000](http://localhost:5000) to check out the demo.

This issue probably affects the other demos, but I haven't used them yet.
